### PR TITLE
[fix] ext-json is included in composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "type": "library",
     "require": {
         "php": ">=5.3",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "ext-json": "*"
     },
     "description": "A wrapper around the ipinfo.io services",
     "require-dev": {


### PR DESCRIPTION
Using `json_decode` function requires PHP JSON extension.