### PR TITLE
[fix] PHPDoc syntax

### DIFF
--- a/src/DavidePastore/Ipinfo/Ipinfo.php
+++ b/src/DavidePastore/Ipinfo/Ipinfo.php
@@ -197,7 +197,7 @@ class Ipinfo
      * @param string $field    The field value.
      * @param string $response The response from the server.
      *
-     * @return Ambigous <\DavidePastore\Ipinfo\Host, string> Returns an Host object if the request is
+     * @return \DavidePastore\Ipinfo\Host|string Returns an Host object if the request is
      *                  of the GEO type, a string otherwise. If the field value is different from the GEO type, it will
      *                  delete the last character ('\n').
      */


### PR DESCRIPTION
I think this error comes from this [bug](https://bugs.eclipse.org/bugs/show_bug.cgi?id=467148). Fixed to correct PHPDoc syntax.